### PR TITLE
Issue#2: Base Java version is too low

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,8 +351,8 @@
           <version>3.6.0</version>
           <configuration>
             <encoding>${project.build.sourceEncoding}</encoding>
-            <source>1.5</source>
-            <target>1.5</target>
+            <source>1.6</source>
+            <target>1.6</target>
             <!--            <compilerArgument>-Xlint:unchecked</compilerArgument>-->
           </configuration>
         </plugin>


### PR DESCRIPTION
Changed the baseline Java version from 1.5 to 1.6 to allow use of Java 6
language features such as @Override